### PR TITLE
config file values being ignored

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -40,12 +40,16 @@ impl AppConfig {
             builder = builder.add_source(File::from(config_path).required(false));
         }
 
-        let c = builder
-            .add_source(Environment::with_prefix("XDRPC").separator("__"))
-            .set_override("hide_file", clap_matches.get_flag(HIDE_FILE_ARG_ID))?
-            .set_override("hide_project", clap_matches.get_flag(HIDE_PROJECT_ARG_ID))?
-            .build()?;
-
+        let mut builder = builder
+            .add_source(Environment::with_prefix("XDRPC").separator("__"));
+        if clap_matches.get_flag(HIDE_FILE_ARG_ID) {
+            builder = builder.set_override("hide_file", true)?;
+        }
+        if clap_matches.get_flag(HIDE_PROJECT_ARG_ID) {
+            builder = builder.set_override("hide_project", true)?;
+        }
+        let c = builder.build()?;
+        
         Ok(c.try_deserialize()?)
     }
 
@@ -60,8 +64,7 @@ impl AppConfig {
                     .long("hide-file")
                     .num_args(0)
                     .action(ArgAction::SetTrue)
-                    .help("Hide current file in Discord Rich Presence")
-                    .default_value("false"),
+                    .help("Hide current file in Discord Rich Presence"),
             )
             .arg(
                 Arg::new(HIDE_PROJECT_ARG_ID)
@@ -69,8 +72,7 @@ impl AppConfig {
                     .long("hide-project")
                     .num_args(0)
                     .action(ArgAction::SetTrue)
-                    .help("Hide current project in Discord Rich Presence")
-                    .default_value("false"),
+                    .help("Hide current project in Discord Rich Presence"),
             )
             .get_matches()
     }

--- a/src/xcode_state.rs
+++ b/src/xcode_state.rs
@@ -190,11 +190,7 @@ impl XcodeState<'_> {
 
     /// Retrieves current project name, respecting hide_project configuration
     fn get_current_project(&self) -> Result<String> {
-        if self.config.hide_project {
-            Ok(String::from(""))
-        } else {
-            current_project()
-        }
+        current_project()
     }
 
     /// Sets Discord activity to idle state

--- a/src/xcode_state.rs
+++ b/src/xcode_state.rs
@@ -190,7 +190,12 @@ impl XcodeState<'_> {
 
     /// Retrieves current project name, respecting hide_project configuration
     fn get_current_project(&self) -> Result<String> {
-        current_project()
+        let project = current_project()?;
+        if self.config.hide_project && !project.is_empty() {
+            Ok(String::from("Project"))
+        } else {
+            Ok(project)
+        }
     }
 
     /// Sets Discord activity to idle state


### PR DESCRIPTION
## Summary
- `set_override()` was overwriting config file values with CLI defaults
- when `hide_project` was enabled, `get_current_project()` returned an empty string, which made the app think no project was open
- docs showed `~/.config/` but macOS uses `~/Library/Application Support/`

## Test plan
- [ ] Test `hide_file = true` and `hide_project = true`
