### PR TITLE
feat(rpc): show current git branch in Rich Presence status

### DIFF
--- a/.github/workflows/brew.yml
+++ b/.github/workflows/brew.yml
@@ -110,7 +110,7 @@ jobs:
         uses: mislav/bump-homebrew-formula-action@v3
         with:
           formula-name: xcode-discord-rpc
-          homebrew-tap: izyuumi/homebrew-xcode-discord-rpc
+          homebrew-tap: izyuumi/homebrew-tap
           commit-message: "Release ${{ steps.get_version.outputs.version }}"
           download-url: https://github.com/izyuumi/xcode-discord-rpc/releases/download/${{ steps.get_version.outputs.version }}/xcode-discord-rpc.tar.gz
           tag-name: ${{ steps.get_version.outputs.version }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,7 @@
 
 ### Features
 
-* improve error types and add --config flag ([d026df2](https://github.com/izyuumi/xcode-discord-rpc/commit/d026df2b6a1f1530affd26d046a31e847c56b9c8))
 * improve error types and add --config flag ([#59](https://github.com/izyuumi/xcode-discord-rpc/issues/59)) ([b8217c6](https://github.com/izyuumi/xcode-discord-rpc/commit/b8217c651e2731ffb4f70fb03c636f6ed299e27a))
-* osascript error propagation, --disable-idle flag, debug logging, graceful shutdown ([e39d97c](https://github.com/izyuumi/xcode-discord-rpc/commit/e39d97cbf03beef139bf39ab6052298fd2820ab8))
 * osascript error propagation, --disable-idle flag, debug logging, graceful shutdown ([#61](https://github.com/izyuumi/xcode-discord-rpc/issues/61)) ([5174e44](https://github.com/izyuumi/xcode-discord-rpc/commit/5174e446cfecc34d8ec95833d19057d1629b280e))
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## [1.4.0](https://github.com/izyuumi/xcode-discord-rpc/compare/v1.3.2...v1.4.0) (2026-02-21)
+
+
+### Features
+
+* improve error types and add --config flag ([d026df2](https://github.com/izyuumi/xcode-discord-rpc/commit/d026df2b6a1f1530affd26d046a31e847c56b9c8))
+* improve error types and add --config flag ([#59](https://github.com/izyuumi/xcode-discord-rpc/issues/59)) ([b8217c6](https://github.com/izyuumi/xcode-discord-rpc/commit/b8217c651e2731ffb4f70fb03c636f6ed299e27a))
+* osascript error propagation, --disable-idle flag, debug logging, graceful shutdown ([e39d97c](https://github.com/izyuumi/xcode-discord-rpc/commit/e39d97cbf03beef139bf39ab6052298fd2820ab8))
+* osascript error propagation, --disable-idle flag, debug logging, graceful shutdown ([#61](https://github.com/izyuumi/xcode-discord-rpc/issues/61)) ([5174e44](https://github.com/izyuumi/xcode-discord-rpc/commit/5174e446cfecc34d8ec95833d19057d1629b280e))
+
+
+### Bug Fixes
+
+* preserve hide_project without breaking project detection ([1974d8b](https://github.com/izyuumi/xcode-discord-rpc/commit/1974d8bc914273088eea36de847149a9433816be))
+
 ## [1.3.2](https://github.com/izyuumi/xcode-discord-rpc/compare/v1.3.1...v1.3.2) (2026-01-21)
 
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1143,7 +1143,7 @@ dependencies = [
 
 [[package]]
 name = "xcode-discord-rpc"
-version = "1.3.2"
+version = "1.4.0"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -126,6 +126,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block2"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
+dependencies = [
+ "objc2",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -145,6 +154,12 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
@@ -286,6 +301,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctrlc"
+version = "3.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0b1fab2ae45819af2d0731d60f2afe17227ebb1a1538a236da84c93e9a60162"
+dependencies = [
+ "dispatch2",
+ "nix",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "deranged"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -314,6 +340,18 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "uuid",
+]
+
+[[package]]
+name = "dispatch2"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89a09f22a6c6069a18470eb92d2298acf25463f14256d24778e1230d789a2aec"
+dependencies = [
+ "bitflags",
+ "block2",
+ "libc",
+ "objc2",
 ]
 
 [[package]]
@@ -458,9 +496,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.149"
+version = "0.2.180"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a08173bc88b7955d1b3145aa561539096c421ac8debde8cbc3612ec635fee29b"
+checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
 
 [[package]]
 name = "log"
@@ -473,6 +511,18 @@ name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+
+[[package]]
+name = "nix"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "225e7cfe711e0ba79a68baeddb2982723e4235247aefce1482f2f16c27865b66"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
 
 [[package]]
 name = "num-conv"
@@ -497,6 +547,21 @@ checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "objc2"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c2599ce0ec54857b29ce62166b0ed9b4f6f1a70ccc9a71165b6154caca8c05"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
 
 [[package]]
 name = "once_cell"
@@ -914,6 +979,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
 name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -929,6 +1000,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]
@@ -1068,6 +1148,7 @@ dependencies = [
  "chrono",
  "clap",
  "config",
+ "ctrlc",
  "discord-rich-presence",
  "log",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xcode-discord-rpc"
-version = "1.3.2"
+version = "1.4.0"
 edition = "2021"
 authors = ["Yumi Izumi <me@yumiizumi.com>"]
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,3 +28,4 @@ simple_logger = { version = "5.0.0", default-features = false, features = [
     "timestamps",
 ] }
 log = "0.4.25"
+ctrlc = "3.4"

--- a/default.toml
+++ b/default.toml
@@ -5,3 +5,4 @@ idle_threshold = 25
 disable_idle = false
 hide_file = false
 hide_project = false
+hide_branch = false

--- a/docs/config.md
+++ b/docs/config.md
@@ -16,14 +16,16 @@ idle_threshold = 300
 disable_idle = false
 hide_file = true
 hide_project = false
+hide_branch = false
 ```
 
 ## Command-Line Arguments
 
-Command-line arguments are also available for `hide-file` and `hide-project`.
+Command-line arguments are also available for `hide-file`, `hide-project`, and `hide-branch`.
 
 - `-f`, `--hide-file`: Hide the current file in Discord Rich Presence.
 - `-p`, `--hide-project`: Hide the current project in Discord Rich Presence.
+- `-b`, `--hide-branch`: Hide the current git branch in Discord Rich Presence.
 
 ## Configuration Options
 
@@ -63,3 +65,9 @@ Command-line arguments are also available for `hide-file` and `hide-project`.
 - **Description**: A boolean value to determine whether to hide the project name in the Discord Rich Presence.
 - **Default**: `false`
 - **Command-Line Flag**: `--hide-project` or `-p`
+
+### `hide_branch`
+
+- **Description**: A boolean value to determine whether to hide the active git branch name in the Discord Rich Presence. When `false`, the branch name is appended to the state string with a bullet separator (e.g. `in MyApp • feat/export`). The branch is resolved via `git rev-parse --abbrev-ref HEAD` from the workspace document path. If the project is not inside a git repository, this field has no effect.
+- **Default**: `false`
+- **Command-Line Flag**: `--hide-branch` or `-b`

--- a/docs/config.md
+++ b/docs/config.md
@@ -68,6 +68,6 @@ Command-line arguments are also available for `hide-file`, `hide-project`, and `
 
 ### `hide_branch`
 
-- **Description**: A boolean value to determine whether to hide the active git branch name in the Discord Rich Presence. When `false`, the branch name is appended to the state string with a bullet separator (e.g. `in MyApp • feat/export`). The branch is resolved via `git rev-parse --abbrev-ref HEAD` from the workspace document path. If the project is not inside a git repository, this field has no effect.
+- **Description**: A boolean value to determine whether to hide the active git branch name in the Discord Rich Presence. When `false`, the branch name is appended to the state string with a bullet separator (e.g. `in MyApp • feat/export`), subject to Discord's 128-byte state limit (not characters — multibyte UTF-8 characters such as `•` and `…` count as multiple bytes, so branch or workspace names may be truncated). The branch is resolved via `git rev-parse --abbrev-ref HEAD` from the workspace document path. If the project is not inside a git repository, this field has no effect.
 - **Default**: `false`
 - **Command-Line Flag**: `--hide-branch` or `-b`

--- a/docs/config.md
+++ b/docs/config.md
@@ -21,8 +21,10 @@ hide_branch = false
 
 ## Command-Line Arguments
 
-Command-line arguments are also available for `hide-file`, `hide-project`, and `hide-branch`.
+Command-line arguments are also available for configuration and feature toggles:
 
+- `-c`, `--config <PATH>`: Path to a custom config file (required if specified).
+- `-i`, `--disable-idle`: Disable idle status detection.
 - `-f`, `--hide-file`: Hide the current file in Discord Rich Presence.
 - `-p`, `--hide-project`: Hide the current project in Discord Rich Presence.
 - `-b`, `--hide-branch`: Hide the current git branch in Discord Rich Presence.

--- a/src/config.rs
+++ b/src/config.rs
@@ -40,12 +40,16 @@ impl AppConfig {
             builder = builder.add_source(File::from(config_path).required(false));
         }
 
-        let c = builder
-            .add_source(Environment::with_prefix("XDRPC").separator("__"))
-            .set_override("hide_file", clap_matches.get_flag(HIDE_FILE_ARG_ID))?
-            .set_override("hide_project", clap_matches.get_flag(HIDE_PROJECT_ARG_ID))?
-            .build()?;
-
+        let mut builder = builder
+            .add_source(Environment::with_prefix("XDRPC").separator("__"));
+        if clap_matches.get_flag(HIDE_FILE_ARG_ID) {
+            builder = builder.set_override("hide_file", true)?;
+        }
+        if clap_matches.get_flag(HIDE_PROJECT_ARG_ID) {
+            builder = builder.set_override("hide_project", true)?;
+        }
+        let c = builder.build()?;
+        
         Ok(c.try_deserialize()?)
     }
 
@@ -60,8 +64,7 @@ impl AppConfig {
                     .long("hide-file")
                     .num_args(0)
                     .action(ArgAction::SetTrue)
-                    .help("Hide current file in Discord Rich Presence")
-                    .default_value("false"),
+                    .help("Hide current file in Discord Rich Presence"),
             )
             .arg(
                 Arg::new(HIDE_PROJECT_ARG_ID)
@@ -69,8 +72,7 @@ impl AppConfig {
                     .long("hide-project")
                     .num_args(0)
                     .action(ArgAction::SetTrue)
-                    .help("Hide current project in Discord Rich Presence")
-                    .default_value("false"),
+                    .help("Hide current project in Discord Rich Presence"),
             )
             .get_matches()
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -9,6 +9,8 @@ const HIDE_FILE_ARG_ID: &str = "hide_file";
 const HIDE_PROJECT_ARG_ID: &str = "hide_project";
 /// Argument ID for the custom config file path
 const CONFIG_ARG_ID: &str = "config";
+/// Argument ID for disabling idle detection
+const DISABLE_IDLE_ARG_ID: &str = "disable_idle";
 /// Content of the default configuration file
 const DEFAULT_CONFIG: &str = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/default.toml"));
 
@@ -59,6 +61,9 @@ impl AppConfig {
         if clap_matches.get_flag(HIDE_PROJECT_ARG_ID) {
             builder = builder.set_override("hide_project", true)?;
         }
+        if clap_matches.get_flag(DISABLE_IDLE_ARG_ID) {
+            builder = builder.set_override("disable_idle", true)?;
+        }
         let c = builder.build()?;
         
         Ok(c.try_deserialize()?)
@@ -76,6 +81,14 @@ impl AppConfig {
                     .num_args(1)
                     .value_name("PATH")
                     .help("Path to a custom config file (required if specified)"),
+            )
+            .arg(
+                Arg::new(DISABLE_IDLE_ARG_ID)
+                    .short('i')
+                    .long("disable-idle")
+                    .num_args(0)
+                    .action(ArgAction::SetTrue)
+                    .help("Disable idle status detection"),
             )
             .arg(
                 Arg::new(HIDE_FILE_ARG_ID)

--- a/src/config.rs
+++ b/src/config.rs
@@ -7,6 +7,8 @@ use std::path::PathBuf;
 const HIDE_FILE_ARG_ID: &str = "hide_file";
 /// Argument ID for hiding the project name in Discord Rich Presence
 const HIDE_PROJECT_ARG_ID: &str = "hide_project";
+/// Argument ID for the custom config file path
+const CONFIG_ARG_ID: &str = "config";
 /// Content of the default configuration file
 const DEFAULT_CONFIG: &str = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/default.toml"));
 
@@ -35,7 +37,12 @@ impl AppConfig {
         let mut builder =
             Config::builder().add_source(File::from_str(DEFAULT_CONFIG, FileFormat::Toml));
 
-        if let Some(home) = std::env::var_os("HOME") {
+        // Config file: use --config path if provided, otherwise default location
+        if let Some(config_path) = clap_matches.get_one::<String>(CONFIG_ARG_ID) {
+            let path = PathBuf::from(config_path);
+            log::debug!("Using custom config file: {:?}", path);
+            builder = builder.add_source(File::from(path).required(true));
+        } else if let Some(home) = std::env::var_os("HOME") {
             let config_path = PathBuf::from(home)
                 .join(".config")
                 .join("xcode-discord-rpc")
@@ -62,6 +69,14 @@ impl AppConfig {
             .version(clap::crate_version!())
             .author(clap::crate_authors!())
             .about("Displays Xcode status on Discord Rich Presence")
+            .arg(
+                Arg::new(CONFIG_ARG_ID)
+                    .short('c')
+                    .long("config")
+                    .num_args(1)
+                    .value_name("PATH")
+                    .help("Path to a custom config file (required if specified)"),
+            )
             .arg(
                 Arg::new(HIDE_FILE_ARG_ID)
                     .short('f')

--- a/src/config.rs
+++ b/src/config.rs
@@ -7,6 +7,8 @@ use std::path::PathBuf;
 const HIDE_FILE_ARG_ID: &str = "hide_file";
 /// Argument ID for hiding the project name in Discord Rich Presence
 const HIDE_PROJECT_ARG_ID: &str = "hide_project";
+/// Argument ID for hiding the git branch in Discord Rich Presence
+const HIDE_BRANCH_ARG_ID: &str = "hide_branch";
 /// Argument ID for the custom config file path
 const CONFIG_ARG_ID: &str = "config";
 /// Argument ID for disabling idle detection
@@ -30,6 +32,8 @@ pub struct AppConfig {
     pub hide_file: bool,
     /// Whether to hide the project name in Discord Rich Presence
     pub hide_project: bool,
+    /// Whether to hide the git branch name in Discord Rich Presence
+    pub hide_branch: bool,
 }
 
 impl AppConfig {
@@ -63,6 +67,9 @@ impl AppConfig {
         }
         if clap_matches.get_flag(DISABLE_IDLE_ARG_ID) {
             builder = builder.set_override("disable_idle", true)?;
+        }
+        if clap_matches.get_flag(HIDE_BRANCH_ARG_ID) {
+            builder = builder.set_override("hide_branch", true)?;
         }
         let c = builder.build()?;
         
@@ -105,6 +112,14 @@ impl AppConfig {
                     .num_args(0)
                     .action(ArgAction::SetTrue)
                     .help("Hide current project in Discord Rich Presence"),
+            )
+            .arg(
+                Arg::new(HIDE_BRANCH_ARG_ID)
+                    .short('b')
+                    .long("hide-branch")
+                    .num_args(0)
+                    .action(ArgAction::SetTrue)
+                    .help("Hide current git branch in Discord Rich Presence"),
             )
             .get_matches()
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -4,12 +4,22 @@ pub type Result<T> = std::result::Result<T, Error>;
 pub enum Error {
     #[error("Config error: {0}")]
     Config(#[from] config::ConfigError),
-    #[error("DiscordIPC error: {0}")]
+    #[error("Discord IPC error: {0}")]
     DiscordIpc(String),
-    #[error("Oascript error: {0}")]
+    #[error("AppleScript error: {0}")]
     Oascript(String),
-    #[error("BoxDyn error: {0}")]
+    #[error("IO error: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("{0}")]
     BoxDyn(#[from] Box<dyn std::error::Error>),
-    #[error("SimpleLogger error: {0}")]
+    #[error("Logger error: {0}")]
     SimpleLogger(#[from] log::SetLoggerError),
+}
+
+impl Error {
+    /// Returns true if the error is transient and may resolve on retry
+    /// (e.g. Discord IPC disconnects, AppleScript timeouts, IO failures).
+    pub fn is_transient(&self) -> bool {
+        matches!(self, Error::DiscordIpc(_) | Error::Oascript(_) | Error::Io(_))
+    }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -20,6 +20,28 @@ impl Error {
     /// Returns true if the error is transient and may resolve on retry
     /// (e.g. Discord IPC disconnects, AppleScript timeouts, IO failures).
     pub fn is_transient(&self) -> bool {
-        matches!(self, Error::DiscordIpc(_) | Error::Oascript(_) | Error::Io(_))
+        match self {
+            // Discord IPC failures are typically recoverable by reconnecting.
+            Error::DiscordIpc(_) => true,
+
+            // AppleScript failures are often transient (Xcode not ready / busy / not responding).
+            Error::Oascript(_) => true,
+
+            // Only treat *some* IO errors as transient; many (e.g. NotFound/PermissionDenied)
+            // are persistent and should not be blindly retried.
+            Error::Io(e) => matches!(
+                e.kind(),
+                std::io::ErrorKind::Interrupted
+                    | std::io::ErrorKind::WouldBlock
+                    | std::io::ErrorKind::TimedOut
+                    | std::io::ErrorKind::ConnectionRefused
+                    | std::io::ErrorKind::ConnectionReset
+                    | std::io::ErrorKind::ConnectionAborted
+                    | std::io::ErrorKind::NotConnected
+                    | std::io::ErrorKind::BrokenPipe
+            ),
+
+            _ => false,
+        }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,7 +42,6 @@ fn main() -> Result<()> {
         if let Err(err) = discord_rpc(&config, &running) {
             log::error!("{}", err);
             log::debug!("Trying to reconnect...");
-            sleep(config.update_interval)
         }
         sleep(config.update_interval)
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,6 @@
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+
 use simple_logger::SimpleLogger;
 
 mod config;
@@ -24,10 +27,19 @@ fn main() -> Result<()> {
 
     let config = AppConfig::new()?;
 
+    let running = Arc::new(AtomicBool::new(true));
+    let running_clone = running.clone();
+
+    ctrlc::set_handler(move || {
+        log::info!("Received shutdown signal, exiting...");
+        running_clone.store(false, Ordering::SeqCst);
+    })
+    .expect("Failed to set signal handler");
+
     log::info!("Starting xcode-discord-rpc");
 
-    loop {
-        if let Err(err) = discord_rpc(&config) {
+    while running.load(Ordering::SeqCst) {
+        if let Err(err) = discord_rpc(&config, &running) {
             log::error!("{}", err);
             log::debug!("Trying to reconnect...");
             sleep(config.update_interval)
@@ -35,17 +47,21 @@ fn main() -> Result<()> {
         sleep(config.update_interval)
     }
 
-    #[allow(unreachable_code)]
+    log::info!("Shutting down cleanly");
     Ok(())
 }
 
-fn discord_rpc(config: &AppConfig) -> Result<()> {
+fn discord_rpc(config: &AppConfig, running: &Arc<AtomicBool>) -> Result<()> {
     let mut client = init_discord_ipc()?;
 
     let mut xcode_state = XcodeState::new(config, &mut client);
 
-    xcode_state.run()?;
+    xcode_state.run(running)?;
 
-    #[allow(unreachable_code)]
+    // Clear activity before disconnecting
+    if let Err(e) = xcode_state.clear_activity() {
+        log::debug!("Failed to clear activity on shutdown: {}", e);
+    }
+
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,7 +43,10 @@ fn main() -> Result<()> {
             log::error!("{}", err);
             log::debug!("Trying to reconnect...");
         }
-        sleep(config.update_interval)
+        // Avoid delaying shutdown: only sleep if we are still running after the RPC attempt.
+        if running.load(Ordering::SeqCst) {
+            sleep(config.update_interval);
+        }
     }
 
     log::info!("Shutting down cleanly");

--- a/src/utils/git.rs
+++ b/src/utils/git.rs
@@ -1,3 +1,4 @@
+use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::sync::OnceLock;
@@ -48,22 +49,7 @@ fn git_command() -> Command {
 /// - the repository is in a detached-HEAD state (returns `"HEAD"`)
 /// - any other git or I/O error occurs
 pub fn get_git_branch(project_path: &str) -> Option<String> {
-    if project_path.is_empty() {
-        return None;
-    }
-
-    // Resolve the directory to run git in: if the path points to a file,
-    // use its parent directory so `git -C` receives a directory.
-    let dir = {
-        let p = Path::new(project_path);
-        if p.is_file() {
-            p.parent()
-                .map(|d| d.to_string_lossy().to_string())
-                .unwrap_or_else(|| project_path.to_string())
-        } else {
-            project_path.to_string()
-        }
-    };
+    let dir = git_work_dir(project_path)?;
 
     let output = git_command()
         .args(["-C", &dir, "rev-parse", "--abbrev-ref", "HEAD"])
@@ -82,6 +68,58 @@ pub fn get_git_branch(project_path: &str) -> Option<String> {
     }
 
     Some(branch)
+}
+
+/// Returns the current contents of the repository's `HEAD` file for the git
+/// repository containing `project_path`.
+///
+/// This is a cheap change detector for branch switches inside the same
+/// workspace: symbolic refs change when switching branches, and detached HEAD
+/// values change when checking out a different commit.
+pub fn get_git_head_ref(project_path: &str) -> Option<String> {
+    let dir = git_work_dir(project_path)?;
+
+    let output = git_command()
+        .args(["-C", &dir, "rev-parse", "--absolute-git-dir"])
+        .output()
+        .ok()?;
+
+    if !output.status.success() {
+        return None;
+    }
+
+    let git_dir = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if git_dir.is_empty() {
+        return None;
+    }
+
+    let head = fs::read_to_string(Path::new(&git_dir).join("HEAD")).ok()?;
+    let head = head.trim().to_string();
+
+    if head.is_empty() {
+        return None;
+    }
+
+    Some(head)
+}
+
+fn git_work_dir(project_path: &str) -> Option<String> {
+    if project_path.is_empty() {
+        return None;
+    }
+
+    // Resolve the directory to run git in: if the path points to a file,
+    // use its parent directory so `git -C` receives a directory.
+    let p = Path::new(project_path);
+    if p.is_file() {
+        Some(
+            p.parent()
+                .map(|d| d.to_string_lossy().to_string())
+                .unwrap_or_else(|| project_path.to_string()),
+        )
+    } else {
+        Some(project_path.to_string())
+    }
 }
 
 /// Truncate a branch name so that the full state string

--- a/src/utils/git.rs
+++ b/src/utils/git.rs
@@ -138,4 +138,41 @@ mod tests {
         assert_eq!(result.len(), 128);
         assert!(!result.contains('…'));
     }
+
+    #[test]
+    fn format_branch_state_base_at_limit() {
+        // base is exactly 128 bytes — should be returned as-is (truncated to limit)
+        let base = "a".repeat(128);
+        let result = format_branch_state(&base, "main").unwrap();
+        assert!(result.len() <= 128);
+        // Branch should not appear when base alone fills the limit
+        assert!(!result.contains("main"));
+    }
+
+    #[test]
+    fn format_branch_state_base_exceeds_limit() {
+        // base exceeds 128 bytes — should be truncated
+        let base = "a".repeat(200);
+        let result = format_branch_state(&base, "main").unwrap();
+        assert!(result.len() <= 128);
+    }
+
+    #[test]
+    fn format_branch_state_multibyte_branch() {
+        // Japanese characters are 3 bytes each in UTF-8
+        let base = "in MyApp";
+        let branch = "機能/新しいブランチ"; // multibyte UTF-8 branch name
+        let result = format_branch_state(base, branch).unwrap();
+        assert!(result.len() <= 128);
+        // Result must be valid UTF-8 (not split mid-character)
+        assert!(std::str::from_utf8(result.as_bytes()).is_ok());
+    }
+
+    #[test]
+    fn format_branch_state_empty_branch() {
+        // Empty branch name — should still produce a valid string
+        let result = format_branch_state("in MyApp", "").unwrap();
+        // With an empty branch the separator + empty string is appended
+        assert!(result.len() <= 128);
+    }
 }

--- a/src/utils/git.rs
+++ b/src/utils/git.rs
@@ -14,7 +14,7 @@ fn git_command() -> Command {
     let git_path = RESOLVED_GIT_PATH.get_or_init(|| {
         // Prefer well-known absolute paths so the binary is found even when PATH
         // is stripped down (e.g. inside a launchd agent).
-        let candidates = ["/usr/bin/git", "/usr/local/bin/git", "/opt/homebrew/bin/git", "git"];
+        let candidates = ["/opt/homebrew/bin/git", "/usr/local/bin/git", "/usr/bin/git", "git"];
 
         for candidate in candidates {
             if candidate == "git" || Path::new(candidate).exists() {

--- a/src/utils/git.rs
+++ b/src/utils/git.rs
@@ -1,0 +1,131 @@
+use std::path::Path;
+use std::process::Command;
+
+/// Returns the name of the active git branch for the repository containing
+/// `project_path`. The path may point to a file or directory; the function
+/// walks upward to find the nearest git repository automatically (via
+/// `git -C <dir>`).
+///
+/// Returns `None` when:
+/// - `project_path` is empty
+/// - the path is not inside a git repository
+/// - the repository is in a detached-HEAD state (returns `"HEAD"`)
+/// - any other git or I/O error occurs
+pub fn get_git_branch(project_path: &str) -> Option<String> {
+    if project_path.is_empty() {
+        return None;
+    }
+
+    // Resolve the directory to run git in: if the path points to a file,
+    // use its parent directory so `git -C` receives a directory.
+    let dir = {
+        let p = Path::new(project_path);
+        if p.is_file() {
+            p.parent()
+                .map(|d| d.to_string_lossy().to_string())
+                .unwrap_or_else(|| project_path.to_string())
+        } else {
+            project_path.to_string()
+        }
+    };
+
+    let output = Command::new("git")
+        .args(["-C", &dir, "rev-parse", "--abbrev-ref", "HEAD"])
+        .output()
+        .ok()?;
+
+    if !output.status.success() {
+        return None;
+    }
+
+    let branch = String::from_utf8_lossy(&output.stdout).trim().to_string();
+
+    // Detached HEAD is not a meaningful branch name to display.
+    if branch.is_empty() || branch == "HEAD" {
+        return None;
+    }
+
+    Some(branch)
+}
+
+/// Truncate a branch name so that the full state string
+/// `"{base} • {branch}"` never exceeds Discord's 128-byte limit.
+///
+/// All length arithmetic is done in UTF-8 bytes (matching Rust's `str::len`)
+/// so the result never overflows the limit even when multi-byte characters
+/// (such as the `•` separator or `…` ellipsis) are present.
+///
+/// Returns `None` when even the base alone would exceed the limit (extremely
+/// unlikely in practice).
+pub fn format_branch_state(base: &str, branch: &str) -> Option<String> {
+    const DISCORD_STATE_LIMIT: usize = 128;
+    const SEPARATOR: &str = " • "; // 5 bytes in UTF-8
+    const ELLIPSIS: &str = "…"; // 3 bytes in UTF-8
+
+    let base_len = base.len();
+
+    if base_len >= DISCORD_STATE_LIMIT {
+        // Edge case: base itself is already at/over the limit.
+        return Some(truncate_to_char_boundary(base, DISCORD_STATE_LIMIT).to_string());
+    }
+
+    let available = DISCORD_STATE_LIMIT - base_len - SEPARATOR.len();
+
+    if branch.len() <= available {
+        // Branch fits without any truncation.
+        Some(format!("{base}{SEPARATOR}{branch}"))
+    } else if available > ELLIPSIS.len() {
+        // Truncate the branch so that branch_bytes + ellipsis_bytes == available.
+        let max_branch_bytes = available - ELLIPSIS.len();
+        let truncated = truncate_to_char_boundary(branch, max_branch_bytes);
+        Some(format!("{base}{SEPARATOR}{truncated}{ELLIPSIS}"))
+    } else {
+        // Not enough room even for one branch character — omit the branch.
+        Some(base.to_string())
+    }
+}
+
+/// Returns a `&str` slice of `s` whose length in bytes is at most `max_bytes`,
+/// truncated at a valid UTF-8 character boundary.
+fn truncate_to_char_boundary(s: &str, max_bytes: usize) -> &str {
+    if s.len() <= max_bytes {
+        return s;
+    }
+    // Walk backwards from max_bytes until we land on a char boundary.
+    let mut end = max_bytes;
+    while end > 0 && !s.is_char_boundary(end) {
+        end -= 1;
+    }
+    &s[..end]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn format_branch_state_short() {
+        let result = format_branch_state("in MyApp", "main").unwrap();
+        assert_eq!(result, "in MyApp • main");
+    }
+
+    #[test]
+    fn format_branch_state_truncates_long_branch() {
+        let base = "in MyApp";
+        // Create a branch name that would exceed the limit
+        let long_branch = "a".repeat(200);
+        let result = format_branch_state(base, &long_branch).unwrap();
+        assert!(result.len() <= 128);
+        assert!(result.contains('…'));
+    }
+
+    #[test]
+    fn format_branch_state_exactly_at_limit() {
+        let base = "in X";
+        // Fill remaining space exactly
+        let branch = "b".repeat(128 - base.len() - " • ".len());
+        let result = format_branch_state(base, &branch).unwrap();
+        assert_eq!(result.len(), 128);
+        assert!(!result.contains('…'));
+    }
+}

--- a/src/utils/git.rs
+++ b/src/utils/git.rs
@@ -1,22 +1,40 @@
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::sync::OnceLock;
 
-
-/// Attempt to run `git` using a list of candidate paths (absolute paths first,
-/// falling back to the bare name so the PATH is still consulted as a last
-/// resort). This is important when the app runs as a macOS launch agent where
-/// PATH is minimal and may not include the directory that contains `git`.
+/// Resolve the `git` binary path once and reuse it for subsequent calls.
+///
+/// We try well-known absolute paths first, then fall back to the bare `git`
+/// name so that PATH is still consulted as a last resort. This is important
+/// when the app runs as a macOS launch agent where PATH is minimal and may not
+/// include the directory that contains `git`.
 fn git_command() -> Command {
-    // Prefer well-known absolute paths so the binary is found even when PATH
-    // is stripped down (e.g. inside a launchd agent).
-    let candidates = ["/usr/bin/git", "/usr/local/bin/git", "/opt/homebrew/bin/git", "git"];
-    for candidate in candidates {
-        if candidate == "git" || std::path::Path::new(candidate).exists() {
-            return Command::new(candidate);
+    static RESOLVED_GIT_PATH: OnceLock<PathBuf> = OnceLock::new();
+
+    let git_path = RESOLVED_GIT_PATH.get_or_init(|| {
+        // Prefer well-known absolute paths so the binary is found even when PATH
+        // is stripped down (e.g. inside a launchd agent).
+        let candidates = ["/usr/bin/git", "/usr/local/bin/git", "/opt/homebrew/bin/git", "git"];
+
+        for candidate in candidates {
+            if candidate == "git" || Path::new(candidate).exists() {
+                // Ensure the candidate is runnable by validating `git --version`.
+                if Command::new(candidate)
+                    .arg("--version")
+                    .output()
+                    .map(|o| o.status.success())
+                    .unwrap_or(false)
+                {
+                    return PathBuf::from(candidate);
+                }
+            }
         }
-    }
-    // Unreachable in practice — "git" is always tried as the final fallback.
-    Command::new("git")
+
+        // Final fallback (should be unreachable in practice because "git" is always tried).
+        PathBuf::from("git")
+    });
+
+    Command::new(git_path)
 }
 
 /// Returns the name of the active git branch for the repository containing

--- a/src/utils/git.rs
+++ b/src/utils/git.rs
@@ -1,6 +1,24 @@
 use std::path::Path;
 use std::process::Command;
 
+
+/// Attempt to run `git` using a list of candidate paths (absolute paths first,
+/// falling back to the bare name so the PATH is still consulted as a last
+/// resort). This is important when the app runs as a macOS launch agent where
+/// PATH is minimal and may not include the directory that contains `git`.
+fn git_command() -> Command {
+    // Prefer well-known absolute paths so the binary is found even when PATH
+    // is stripped down (e.g. inside a launchd agent).
+    let candidates = ["/usr/bin/git", "/usr/local/bin/git", "git"];
+    for candidate in candidates {
+        if candidate == "git" || std::path::Path::new(candidate).exists() {
+            return Command::new(candidate);
+        }
+    }
+    // Unreachable in practice — "git" is always tried as the final fallback.
+    Command::new("git")
+}
+
 /// Returns the name of the active git branch for the repository containing
 /// `project_path`. The path may point to a file or directory; the function
 /// walks upward to find the nearest git repository automatically (via
@@ -29,7 +47,7 @@ pub fn get_git_branch(project_path: &str) -> Option<String> {
         }
     };
 
-    let output = Command::new("git")
+    let output = git_command()
         .args(["-C", &dir, "rev-parse", "--abbrev-ref", "HEAD"])
         .output()
         .ok()?;
@@ -56,9 +74,9 @@ pub fn get_git_branch(project_path: &str) -> Option<String> {
 /// (such as the `•` separator or `…` ellipsis) are present.
 ///
 /// When the base alone meets or exceeds the limit it is truncated to fit and
-/// returned as `Some(truncated_base)` — `None` is never returned by this
-/// function.
-pub fn format_branch_state(base: &str, branch: &str) -> Option<String> {
+/// returned as a `String`. This function always returns a valid `String` and
+/// never fails.
+pub fn format_branch_state(base: &str, branch: &str) -> String {
     const DISCORD_STATE_LIMIT: usize = 128;
     const SEPARATOR: &str = " • "; // 5 bytes in UTF-8
     const ELLIPSIS: &str = "…"; // 3 bytes in UTF-8
@@ -67,7 +85,7 @@ pub fn format_branch_state(base: &str, branch: &str) -> Option<String> {
 
     if base_len >= DISCORD_STATE_LIMIT {
         // Edge case: base itself is already at/over the limit.
-        return Some(truncate_to_char_boundary(base, DISCORD_STATE_LIMIT).to_string());
+        return truncate_to_char_boundary(base, DISCORD_STATE_LIMIT).to_string();
     }
 
     // Use checked_sub to avoid potential underflow when base_len is close to
@@ -76,22 +94,22 @@ pub fn format_branch_state(base: &str, branch: &str) -> Option<String> {
     let available = match DISCORD_STATE_LIMIT.checked_sub(base_len + SEPARATOR.len()) {
         None | Some(0) => {
             // Not enough room for even the separator — return truncated base.
-            return Some(truncate_to_char_boundary(base, DISCORD_STATE_LIMIT).to_string());
+            return truncate_to_char_boundary(base, DISCORD_STATE_LIMIT).to_string();
         }
         Some(n) => n,
     };
 
     if branch.len() <= available {
         // Branch fits without any truncation.
-        Some(format!("{base}{SEPARATOR}{branch}"))
+        format!("{base}{SEPARATOR}{branch}")
     } else if available > ELLIPSIS.len() {
         // Truncate the branch so that branch_bytes + ellipsis_bytes == available.
         let max_branch_bytes = available - ELLIPSIS.len();
         let truncated = truncate_to_char_boundary(branch, max_branch_bytes);
-        Some(format!("{base}{SEPARATOR}{truncated}{ELLIPSIS}"))
+        format!("{base}{SEPARATOR}{truncated}{ELLIPSIS}")
     } else {
         // Not enough room even for one branch character — omit the branch.
-        Some(base.to_string())
+        base.to_string()
     }
 }
 
@@ -115,7 +133,7 @@ mod tests {
 
     #[test]
     fn format_branch_state_short() {
-        let result = format_branch_state("in MyApp", "main").unwrap();
+        let result = format_branch_state("in MyApp", "main");
         assert_eq!(result, "in MyApp • main");
     }
 
@@ -124,7 +142,7 @@ mod tests {
         let base = "in MyApp";
         // Create a branch name that would exceed the limit
         let long_branch = "a".repeat(200);
-        let result = format_branch_state(base, &long_branch).unwrap();
+        let result = format_branch_state(base, &long_branch);
         assert!(result.len() <= 128);
         assert!(result.contains('…'));
     }
@@ -134,7 +152,7 @@ mod tests {
         let base = "in X";
         // Fill remaining space exactly
         let branch = "b".repeat(128 - base.len() - " • ".len());
-        let result = format_branch_state(base, &branch).unwrap();
+        let result = format_branch_state(base, &branch);
         assert_eq!(result.len(), 128);
         assert!(!result.contains('…'));
     }
@@ -143,7 +161,7 @@ mod tests {
     fn format_branch_state_base_at_limit() {
         // base is exactly 128 bytes — should be returned as-is (truncated to limit)
         let base = "a".repeat(128);
-        let result = format_branch_state(&base, "main").unwrap();
+        let result = format_branch_state(&base, "main");
         assert!(result.len() <= 128);
         // Branch should not appear when base alone fills the limit
         assert!(!result.contains("main"));
@@ -153,7 +171,7 @@ mod tests {
     fn format_branch_state_base_exceeds_limit() {
         // base exceeds 128 bytes — should be truncated
         let base = "a".repeat(200);
-        let result = format_branch_state(&base, "main").unwrap();
+        let result = format_branch_state(&base, "main");
         assert!(result.len() <= 128);
     }
 
@@ -162,7 +180,7 @@ mod tests {
         // Japanese characters are 3 bytes each in UTF-8
         let base = "in MyApp";
         let branch = "機能/新しいブランチ"; // multibyte UTF-8 branch name
-        let result = format_branch_state(base, branch).unwrap();
+        let result = format_branch_state(base, branch);
         assert!(result.len() <= 128);
         // Result must be valid UTF-8 (not split mid-character)
         assert!(std::str::from_utf8(result.as_bytes()).is_ok());
@@ -171,8 +189,9 @@ mod tests {
     #[test]
     fn format_branch_state_empty_branch() {
         // Empty branch name — should still produce a valid string
-        let result = format_branch_state("in MyApp", "").unwrap();
-        // With an empty branch the separator + empty string is appended
+        let result = format_branch_state("in MyApp", "");
+        // Expected: "in MyApp • " (base + separator + empty string)
+        assert_eq!(result, "in MyApp \u{2022} ");
         assert!(result.len() <= 128);
     }
 }

--- a/src/utils/git.rs
+++ b/src/utils/git.rs
@@ -55,8 +55,9 @@ pub fn get_git_branch(project_path: &str) -> Option<String> {
 /// so the result never overflows the limit even when multi-byte characters
 /// (such as the `•` separator or `…` ellipsis) are present.
 ///
-/// Returns `None` when even the base alone would exceed the limit (extremely
-/// unlikely in practice).
+/// When the base alone meets or exceeds the limit it is truncated to fit and
+/// returned as `Some(truncated_base)` — `None` is never returned by this
+/// function.
 pub fn format_branch_state(base: &str, branch: &str) -> Option<String> {
     const DISCORD_STATE_LIMIT: usize = 128;
     const SEPARATOR: &str = " • "; // 5 bytes in UTF-8
@@ -69,7 +70,16 @@ pub fn format_branch_state(base: &str, branch: &str) -> Option<String> {
         return Some(truncate_to_char_boundary(base, DISCORD_STATE_LIMIT).to_string());
     }
 
-    let available = DISCORD_STATE_LIMIT - base_len - SEPARATOR.len();
+    // Use checked_sub to avoid potential underflow when base_len is close to
+    // the limit (e.g. base_len == DISCORD_STATE_LIMIT - 1 would leave no room
+    // for the separator).
+    let available = match DISCORD_STATE_LIMIT.checked_sub(base_len + SEPARATOR.len()) {
+        None | Some(0) => {
+            // Not enough room for even the separator — return truncated base.
+            return Some(truncate_to_char_boundary(base, DISCORD_STATE_LIMIT).to_string());
+        }
+        Some(n) => n,
+    };
 
     if branch.len() <= available {
         // Branch fits without any truncation.

--- a/src/utils/git.rs
+++ b/src/utils/git.rs
@@ -9,7 +9,7 @@ use std::process::Command;
 fn git_command() -> Command {
     // Prefer well-known absolute paths so the binary is found even when PATH
     // is stripped down (e.g. inside a launchd agent).
-    let candidates = ["/usr/bin/git", "/usr/local/bin/git", "git"];
+    let candidates = ["/usr/bin/git", "/usr/local/bin/git", "/opt/homebrew/bin/git", "git"];
     for candidate in candidates {
         if candidate == "git" || std::path::Path::new(candidate).exists() {
             return Command::new(candidate);

--- a/src/utils/git.rs
+++ b/src/utils/git.rs
@@ -99,6 +99,11 @@ pub fn format_branch_state(base: &str, branch: &str) -> String {
         Some(n) => n,
     };
 
+    // Empty branch would produce a trailing separator — return base only.
+    if branch.is_empty() {
+        return base.to_string();
+    }
+
     if branch.len() <= available {
         // Branch fits without any truncation.
         format!("{base}{SEPARATOR}{branch}")
@@ -188,10 +193,9 @@ mod tests {
 
     #[test]
     fn format_branch_state_empty_branch() {
-        // Empty branch name — should still produce a valid string
+        // Empty branch name — should return base without trailing separator
         let result = format_branch_state("in MyApp", "");
-        // Expected: "in MyApp • " (base + separator + empty string)
-        assert_eq!(result, "in MyApp \u{2022} ");
+        assert_eq!(result, "in MyApp");
         assert!(result.len() <= 128);
     }
 }

--- a/src/utils/git.rs
+++ b/src/utils/git.rs
@@ -30,7 +30,7 @@ fn git_command() -> Command {
             }
         }
 
-        // Final fallback (should be unreachable in practice because "git" is always tried).
+        // Final fallback (when no candidate passed the usability check).
         PathBuf::from("git")
     });
 

--- a/src/utils/git.rs
+++ b/src/utils/git.rs
@@ -187,8 +187,6 @@ mod tests {
         let branch = "機能/新しいブランチ"; // multibyte UTF-8 branch name
         let result = format_branch_state(base, branch);
         assert!(result.len() <= 128);
-        // Result must be valid UTF-8 (not split mid-character)
-        assert!(std::str::from_utf8(result.as_bytes()).is_ok());
     }
 
     #[test]

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -2,6 +2,7 @@ use discord_rich_presence::DiscordIpcClient;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 pub mod file_language;
+pub mod git;
 pub mod osascript;
 
 use crate::{Error, Result};

--- a/src/utils/osascript.rs
+++ b/src/utils/osascript.rs
@@ -98,6 +98,27 @@ pub fn current_project() -> Result<String> {
     Ok(project)
 }
 
+/// Get the filesystem path of the currently active Xcode workspace/project document.
+///
+/// Returns an empty string when no workspace is open or the AppleScript call
+/// fails (e.g. Xcode is not responding).
+pub fn current_project_path() -> Result<String> {
+    let raw = run_osascript(
+        r#"
+        tell application "Xcode"
+            set doc to active workspace document
+            if doc is missing value then
+                return ""
+            end if
+            return path of doc
+        end tell
+    "#,
+    )
+    .unwrap_or_default();
+    log::debug!("current_project_path raw: {:?}", raw);
+    Ok(raw)
+}
+
 /// Check if frontmost application is Xcode
 pub fn is_xcode_frontmost() -> Result<bool> {
     let frontmost_app = run_osascript(

--- a/src/utils/osascript.rs
+++ b/src/utils/osascript.rs
@@ -8,7 +8,17 @@ pub fn run_osascript(script: &str) -> Result<String> {
         .arg("-e")
         .arg(script)
         .output()
-        .map_err(|err| Error::Oascript(err.to_string()))?;
+        .map_err(|err| Error::Oascript(format!("failed to spawn osascript: {err}")))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        let code = output.status.code().unwrap_or(-1);
+        log::debug!("osascript failed (exit {}): {}", code, stderr);
+        return Err(Error::Oascript(format!(
+            "osascript exited with code {code}: {stderr}"
+        )));
+    }
+
     Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
 }
 
@@ -26,35 +36,65 @@ pub fn check_xcode() -> Result<bool> {
 
 /// Get the current file's name as a String
 pub fn current_file() -> Result<String> {
-    let file = run_osascript(
+    let raw = run_osascript(
         r#"
         tell application "Xcode"
             return name of windows whose index is 1
         end tell
     "#,
     )?;
-    if !file.contains(" — ") {
-        return Ok(file);
-    }
-    let file = file.split(" — ").collect::<Vec<&str>>()[1];
-    Ok(file.to_string())
+    log::debug!("current_file raw: {:?}", raw);
+
+    let file = if raw.contains(" — ") {
+        raw.split(" — ").collect::<Vec<&str>>()[1].to_string()
+    } else {
+        raw
+    };
+    log::debug!("current_file parsed: {:?}", file);
+    Ok(file)
+}
+
+/// Get the current file from the source editor document path (more reliable than window title parsing)
+pub fn current_file_from_source_editor() -> Result<String> {
+    let raw = run_osascript(
+        r#"
+        tell application "Xcode"
+            set doc to front document
+            return path of doc
+        end tell
+    "#,
+    )?;
+    log::debug!("current_file_from_source_editor raw: {:?}", raw);
+
+    // Extract just the filename from the full path
+    let file = raw
+        .rsplit('/')
+        .next()
+        .unwrap_or(&raw)
+        .to_string();
+    log::debug!("current_file_from_source_editor parsed: {:?}", file);
+    Ok(file)
 }
 
 /// Get the current project's name as a String
 pub fn current_project() -> Result<String> {
-    let project = run_osascript(
+    let raw = run_osascript(
         r#"
         tell application "Xcode"
             return active workspace document
         end tell
     "#,
     )?;
-    if project == "missing value" {
-        return Ok(String::new());
-    }
-    if project.starts_with("workspace document ") {
-        return Ok(project.replace("workspace document ", ""));
-    }
+    log::debug!("current_project raw: {:?}", raw);
+
+    let project = if raw == "missing value" {
+        String::new()
+    } else if raw.starts_with("workspace document ") {
+        raw.replace("workspace document ", "")
+    } else {
+        raw
+    };
+    log::debug!("current_project parsed: {:?}", project);
     Ok(project)
 }
 

--- a/src/utils/osascript.rs
+++ b/src/utils/osascript.rs
@@ -113,8 +113,7 @@ pub fn current_project_path() -> Result<String> {
             return path of doc
         end tell
     "#,
-    )
-    .unwrap_or_default();
+    )?;
     log::debug!("current_project_path raw: {:?}", raw);
     Ok(raw)
 }

--- a/src/utils/osascript.rs
+++ b/src/utils/osascript.rs
@@ -45,10 +45,9 @@ pub fn current_file() -> Result<String> {
     )?;
     log::debug!("current_file raw: {:?}", raw);
 
-    let file = if raw.contains(" — ") {
-        raw.split(" — ").collect::<Vec<&str>>()[1].to_string()
-    } else {
-        raw
+    let file = match raw.split_once(" — ") {
+        Some((_, file)) => file.to_string(),
+        None => raw,
     };
     log::debug!("current_file parsed: {:?}", file);
     Ok(file)
@@ -100,8 +99,9 @@ pub fn current_project() -> Result<String> {
 
 /// Get the filesystem path of the currently active Xcode workspace/project document.
 ///
-/// Returns an empty string when no workspace is open or the AppleScript call
-/// fails (e.g. Xcode is not responding).
+/// Returns an empty string when no workspace is open.
+///
+/// Any AppleScript/osascript execution errors are propagated via `Result`.
 pub fn current_project_path() -> Result<String> {
     let raw = run_osascript(
         r#"

--- a/src/xcode_state.rs
+++ b/src/xcode_state.rs
@@ -177,10 +177,16 @@ impl XcodeState<'_> {
             let branch = if self.config.hide_branch {
                 None
             } else {
-                let project_path = current_project_path().unwrap_or_default();
-                log::debug!("Resolving git branch for path: {:?}", project_path);
+                let project_path = current_project_path().unwrap_or_default(); // errors treated as empty path
+                // Log only the basename to avoid leaking full filesystem paths.
+                let path_basename = std::path::Path::new(&project_path)
+                    .file_name()
+                    .map(|n| n.to_string_lossy().to_string())
+                    .unwrap_or_else(|| "<unknown>".to_string());
+                log::debug!("Resolving git branch for path: {:?}", path_basename);
                 let b = get_git_branch(&project_path);
-                log::debug!("Git branch: {:?}", b);
+                // Log only whether a branch was found, not its name.
+                log::debug!("Git branch resolved: {}", if b.is_some() { "yes" } else { "no" });
                 b
             };
 

--- a/src/xcode_state.rs
+++ b/src/xcode_state.rs
@@ -184,8 +184,8 @@ impl XcodeState<'_> {
             }
 
             // Resolve git branch from the active workspace document path.
-            // Results are cached for BRANCH_CACHE_TTL to reduce AppleScript and
-            // subprocess overhead on every update cycle (default 5 s).
+            // Results are cached for BRANCH_CACHE_TTL to reduce git subprocess overhead.
+            // Note: current_project_path() (AppleScript) still runs every update cycle.
             const BRANCH_CACHE_TTL: Duration = Duration::from_secs(30);
             let branch = if self.config.hide_branch {
                 None

--- a/src/xcode_state.rs
+++ b/src/xcode_state.rs
@@ -232,7 +232,11 @@ impl XcodeState<'_> {
                         self.cached_head_ref = Some(head_ref);
                         self.cache_populated_at = Some(Instant::now());
                     } else {
-                        log::debug!("Preserving cached git branch after lookup failure");
+                        log::debug!("Clearing cached git branch after lookup failure");
+                        self.cached_project_path = Some(project_path);
+                        self.cached_branch = Some(None);
+                        self.cached_head_ref = Some(head_ref);
+                        self.cache_populated_at = Some(Instant::now());
                     }
                 } else {
                     log::debug!("Using cached project path and git branch");

--- a/src/xcode_state.rs
+++ b/src/xcode_state.rs
@@ -1,3 +1,6 @@
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+
 use discord_rich_presence::{
     activity::{Activity, Assets, Timestamps},
     DiscordIpc, DiscordIpcClient,
@@ -46,8 +49,8 @@ impl<'a> XcodeState<'a> {
     }
 
     /// Runs the main loop that monitors Xcode and updates Discord Rich Presence
-    pub fn run(&mut self) -> Result<()> {
-        loop {
+    pub fn run(&mut self, running: &Arc<AtomicBool>) -> Result<()> {
+        while running.load(Ordering::SeqCst) {
             // check xcode
             if let Flow::Continue(()) = self.check_xcode_cycle()? {
                 continue;
@@ -70,7 +73,6 @@ impl<'a> XcodeState<'a> {
             self.sleep_xcode_update();
         }
 
-        #[allow(unreachable_code)]
         Ok(())
     }
 
@@ -239,7 +241,7 @@ impl XcodeState<'_> {
     }
 
     /// Clear the Discord activity
-    fn clear_activity(&mut self) -> Result<()> {
+    pub fn clear_activity(&mut self) -> Result<()> {
         self.discord_ipc.clear_activity()?;
         Ok(())
     }

--- a/src/xcode_state.rs
+++ b/src/xcode_state.rs
@@ -12,7 +12,7 @@ use crate::{
     utils::{
         current_time,
         file_language::{FileExtention, FileLanguage, ToFileLanguage},
-        git::{format_branch_state, get_git_branch},
+        git::{format_branch_state, get_git_branch, get_git_head_ref},
         osascript::{check_xcode, current_file, current_project, current_project_path, is_xcode_frontmost},
         sleep,
     },
@@ -39,6 +39,8 @@ pub struct XcodeState<'a> {
     cached_project_path: Option<String>,
     /// TTL cache for the git branch resolved from the project path.
     cached_branch: Option<Option<String>>,
+    /// Latest observed git HEAD marker for the cached project path.
+    cached_head_ref: Option<Option<String>>,
     /// Timestamp of the last cache population.
     cache_populated_at: Option<Instant>,
 }
@@ -55,6 +57,7 @@ impl<'a> XcodeState<'a> {
             sleep_multiplier: 1,
             cached_project_path: None,
             cached_branch: None,
+            cached_head_ref: None,
             cache_populated_at: None,
         }
     }
@@ -179,7 +182,8 @@ impl XcodeState<'_> {
             }
 
             // Resolve git branch from the active workspace document path.
-            // Results are cached for BRANCH_CACHE_TTL to reduce git subprocess overhead.
+            // Results are cached for BRANCH_CACHE_TTL, but invalidate early when
+            // the repository HEAD changes so branch switches are reflected quickly.
             // Note: current_project_path() (AppleScript) still runs every update cycle.
             const BRANCH_CACHE_TTL: Duration = Duration::from_secs(30);
             let branch = if self.config.hide_branch {
@@ -198,7 +202,15 @@ impl XcodeState<'_> {
                     .as_deref()
                     .map(|p| p != project_path.as_str())
                     .unwrap_or(true);
+                let head_ref = get_git_head_ref(&project_path);
+                let head_changed = !project_changed
+                    && self
+                        .cached_head_ref
+                        .as_ref()
+                        .map(|cached| cached != &head_ref)
+                        .unwrap_or(false);
                 let cache_expired = project_changed
+                    || head_changed
                     || self
                         .cache_populated_at
                         .map(|t| t.elapsed() >= BRANCH_CACHE_TTL)
@@ -216,6 +228,7 @@ impl XcodeState<'_> {
                     log::debug!("Git branch resolved: {}", if b.is_some() { "yes" } else { "no" });
                     self.cached_project_path = Some(project_path);
                     self.cached_branch = Some(b);
+                    self.cached_head_ref = Some(head_ref);
                     self.cache_populated_at = Some(Instant::now());
                 } else {
                     log::debug!("Using cached project path and git branch");
@@ -243,6 +256,7 @@ impl XcodeState<'_> {
         // Clear cached path/branch info so the next Xcode session starts fresh.
         self.cached_project_path = None;
         self.cached_branch = None;
+        self.cached_head_ref = None;
         self.cache_populated_at = None;
         Ok(())
     }

--- a/src/xcode_state.rs
+++ b/src/xcode_state.rs
@@ -190,11 +190,7 @@ impl XcodeState<'_> {
 
     /// Retrieves current project name, respecting hide_project configuration
     fn get_current_project(&self) -> Result<String> {
-        if self.config.hide_project {
-            Ok(String::from(""))
-        } else {
-            current_project()
-        }
+        current_project()
     }
 
     /// Sets Discord activity to idle state

--- a/src/xcode_state.rs
+++ b/src/xcode_state.rs
@@ -11,7 +11,8 @@ use crate::{
     utils::{
         current_time,
         file_language::{FileExtention, FileLanguage, ToFileLanguage},
-        osascript::{check_xcode, current_file, current_project, is_xcode_frontmost},
+        git::{format_branch_state, get_git_branch},
+        osascript::{check_xcode, current_file, current_project, current_project_path, is_xcode_frontmost},
         sleep,
     },
     Result,
@@ -172,7 +173,18 @@ impl XcodeState<'_> {
                 continue;
             }
 
-            self.set_working_activity(&project, &started_at)?;
+            // Resolve git branch from the active workspace document path.
+            let branch = if self.config.hide_branch {
+                None
+            } else {
+                let project_path = current_project_path().unwrap_or_default();
+                log::debug!("Resolving git branch for path: {:?}", project_path);
+                let b = get_git_branch(&project_path);
+                log::debug!("Git branch: {:?}", b);
+                b
+            };
+
+            self.set_working_activity(&project, &started_at, branch.as_deref())?;
             self.sleep_xcode_update();
             self.check_xcode()?;
         }
@@ -218,10 +230,15 @@ impl XcodeState<'_> {
     }
 
     /// Sets Discord activity to working state with project and file information
-    fn set_working_activity(&mut self, project: &str, started_at: &Timestamps) -> Result<()> {
+    fn set_working_activity(
+        &mut self,
+        project: &str,
+        started_at: &Timestamps,
+        branch: Option<&str>,
+    ) -> Result<()> {
         // Get all data first
         let (details, (large_text, large_image)) = self.get_file_details()?;
-        let state = self.get_project_state(project);
+        let state = self.get_project_state(project, branch);
 
         // Now use the data to set activity
         let activity = Activity::new()
@@ -270,12 +287,24 @@ impl XcodeState<'_> {
         Ok((details, keys))
     }
 
-    /// Generates state text based on project name and configuration
-    fn get_project_state(&self, project: &str) -> String {
-        if self.config.hide_project {
+    /// Generates state text based on project name, configuration and optional git branch.
+    ///
+    /// When `hide_branch` is `false` and a branch name is available, the branch
+    /// is appended to the state string with a bullet separator, e.g.
+    /// `"in MyApp • feat/export"`. Long branch names are gracefully truncated
+    /// so the combined string never exceeds Discord's 128-character state limit.
+    fn get_project_state(&self, project: &str, branch: Option<&str>) -> String {
+        let base = if self.config.hide_project {
             String::from("in a Project")
         } else {
             format!("in {project}")
+        };
+
+        match branch {
+            Some(b) if !self.config.hide_branch => {
+                format_branch_state(&base, b).unwrap_or(base)
+            }
+            _ => base,
         }
     }
 }

--- a/src/xcode_state.rs
+++ b/src/xcode_state.rs
@@ -190,7 +190,12 @@ impl XcodeState<'_> {
 
     /// Retrieves current project name, respecting hide_project configuration
     fn get_current_project(&self) -> Result<String> {
-        current_project()
+        let project = current_project()?;
+        if self.config.hide_project && !project.is_empty() {
+            Ok(String::from("Project"))
+        } else {
+            Ok(project)
+        }
     }
 
     /// Sets Discord activity to idle state

--- a/src/xcode_state.rs
+++ b/src/xcode_state.rs
@@ -308,7 +308,7 @@ impl XcodeState<'_> {
 
         match branch {
             Some(b) if !self.config.hide_branch => {
-                format_branch_state(&base, b).unwrap_or(base)
+                format_branch_state(&base, b)
             }
             _ => base,
         }

--- a/src/xcode_state.rs
+++ b/src/xcode_state.rs
@@ -190,11 +190,18 @@ impl XcodeState<'_> {
             let branch = if self.config.hide_branch {
                 None
             } else {
-                let project_path = current_project_path().unwrap_or_default();
+                let project_path = match current_project_path() {
+                    Ok(p) => p,
+                    Err(e) => {
+                        // Avoid leaking full filesystem paths in logs.
+                        log::debug!("Failed to resolve active project path: {}", e);
+                        String::new()
+                    }
+                };
                 let project_changed = self
                     .cached_project_path
                     .as_deref()
-                    .map(|p| p != project_path)
+                    .map(|p| p != project_path.as_str())
                     .unwrap_or(true);
                 let cache_expired = project_changed
                     || self

--- a/src/xcode_state.rs
+++ b/src/xcode_state.rs
@@ -307,7 +307,7 @@ impl XcodeState<'_> {
         };
 
         match branch {
-            Some(b) if !self.config.hide_branch => {
+            Some(b) => {
                 format_branch_state(&base, b)
             }
             _ => base,

--- a/src/xcode_state.rs
+++ b/src/xcode_state.rs
@@ -226,10 +226,14 @@ impl XcodeState<'_> {
                     let b = get_git_branch(&project_path);
                     // Log only whether a branch was found, not its name.
                     log::debug!("Git branch resolved: {}", if b.is_some() { "yes" } else { "no" });
-                    self.cached_project_path = Some(project_path);
-                    self.cached_branch = Some(b);
-                    self.cached_head_ref = Some(head_ref);
-                    self.cache_populated_at = Some(Instant::now());
+                    if let Some(branch) = b {
+                        self.cached_project_path = Some(project_path);
+                        self.cached_branch = Some(Some(branch));
+                        self.cached_head_ref = Some(head_ref);
+                        self.cache_populated_at = Some(Instant::now());
+                    } else {
+                        log::debug!("Preserving cached git branch after lookup failure");
+                    }
                 } else {
                     log::debug!("Using cached project path and git branch");
                 }

--- a/src/xcode_state.rs
+++ b/src/xcode_state.rs
@@ -156,7 +156,7 @@ impl XcodeState<'_> {
     /// Manages the Discord session and continuously updates Rich Presence based on Xcode activity
     fn handle_discord_session(&mut self) -> Result<()> {
         let mut started_at = Timestamps::new().start(current_time() * 1000);
-        let mut project_before = String::from("");
+        let mut state_before: (String, Option<String>) = (String::from(""), None);
         let mut last_frontmost_at = current_time();
 
         self.reset_sleep_multiplier();
@@ -166,11 +166,6 @@ impl XcodeState<'_> {
 
             self.update_frontmost_time(&mut last_frontmost_at)?;
             let project = self.get_current_project()?;
-
-            if !project_before.eq(&project) {
-                started_at = Timestamps::new().start(current_time() * 1000);
-                project_before = project.clone();
-            }
 
             let is_idle = !self.config.disable_idle
                 && current_time() - last_frontmost_at > self.config.idle_threshold;
@@ -229,6 +224,14 @@ impl XcodeState<'_> {
                 self.cached_branch.clone().flatten()
             };
 
+            // Reset the session timer when either the project or git branch changes.
+            // (This improves accuracy when switching branches without changing project.)
+            let state_now = (project.clone(), branch.clone());
+            if state_before != state_now {
+                started_at = Timestamps::new().start(current_time() * 1000);
+                state_before = state_now;
+            }
+
             self.set_working_activity(&project, &started_at, branch.as_deref())?;
             self.sleep_xcode_update();
             self.check_xcode()?;
@@ -236,6 +239,11 @@ impl XcodeState<'_> {
 
         log::info!("Xcode stopped, clearing Discord activity");
         self.clear_activity()?;
+
+        // Clear cached path/branch info so the next Xcode session starts fresh.
+        self.cached_project_path = None;
+        self.cached_branch = None;
+        self.cache_populated_at = None;
         Ok(())
     }
 

--- a/src/xcode_state.rs
+++ b/src/xcode_state.rs
@@ -298,7 +298,7 @@ impl XcodeState<'_> {
     /// When `hide_branch` is `false` and a branch name is available, the branch
     /// is appended to the state string with a bullet separator, e.g.
     /// `"in MyApp • feat/export"`. Long branch names are gracefully truncated
-    /// so the combined string never exceeds Discord's 128-character state limit.
+    /// so the combined string never exceeds Discord's 128-byte state limit.
     fn get_project_state(&self, project: &str, branch: Option<&str>) -> String {
         let base = if self.config.hide_project {
             String::from("in a Project")

--- a/src/xcode_state.rs
+++ b/src/xcode_state.rs
@@ -1,5 +1,6 @@
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
+use std::time::{Duration, Instant};
 
 use discord_rich_presence::{
     activity::{Activity, Assets, Timestamps},
@@ -34,6 +35,12 @@ pub struct XcodeState<'a> {
     /// Multiplier used to progressively increase sleep duration when Xcode or
     /// Discord is not running. This helps reduce CPU usage when idle.
     sleep_multiplier: u64,
+    /// TTL cache for the project path resolved via AppleScript.
+    cached_project_path: Option<String>,
+    /// TTL cache for the git branch resolved from the project path.
+    cached_branch: Option<Option<String>>,
+    /// Timestamp of the last cache population.
+    cache_populated_at: Option<Instant>,
 }
 
 impl<'a> XcodeState<'a> {
@@ -46,6 +53,9 @@ impl<'a> XcodeState<'a> {
             discord_ipc,
             discord_is_connected: false,
             sleep_multiplier: 1,
+            cached_project_path: None,
+            cached_branch: None,
+            cache_populated_at: None,
         }
     }
 
@@ -174,20 +184,42 @@ impl XcodeState<'_> {
             }
 
             // Resolve git branch from the active workspace document path.
+            // Results are cached for BRANCH_CACHE_TTL to reduce AppleScript and
+            // subprocess overhead on every update cycle (default 5 s).
+            const BRANCH_CACHE_TTL: Duration = Duration::from_secs(30);
             let branch = if self.config.hide_branch {
                 None
             } else {
-                let project_path = current_project_path().unwrap_or_default(); // errors treated as empty path
-                // Log only the basename to avoid leaking full filesystem paths.
-                let path_basename = std::path::Path::new(&project_path)
-                    .file_name()
-                    .map(|n| n.to_string_lossy().to_string())
-                    .unwrap_or_else(|| "<unknown>".to_string());
-                log::debug!("Resolving git branch for path: {:?}", path_basename);
-                let b = get_git_branch(&project_path);
-                // Log only whether a branch was found, not its name.
-                log::debug!("Git branch resolved: {}", if b.is_some() { "yes" } else { "no" });
-                b
+                let project_path = current_project_path().unwrap_or_default();
+                let project_changed = self
+                    .cached_project_path
+                    .as_deref()
+                    .map(|p| p != project_path)
+                    .unwrap_or(true);
+                let cache_expired = project_changed
+                    || self
+                        .cache_populated_at
+                        .map(|t| t.elapsed() >= BRANCH_CACHE_TTL)
+                        .unwrap_or(true);
+
+                if cache_expired {
+                    // Log only the basename to avoid leaking full filesystem paths.
+                    let path_basename = std::path::Path::new(&project_path)
+                        .file_name()
+                        .map(|n| n.to_string_lossy().to_string())
+                        .unwrap_or_else(|| "<unknown>".to_string());
+                    log::debug!("Resolving git branch for path: {:?}", path_basename);
+                    let b = get_git_branch(&project_path);
+                    // Log only whether a branch was found, not its name.
+                    log::debug!("Git branch resolved: {}", if b.is_some() { "yes" } else { "no" });
+                    self.cached_project_path = Some(project_path);
+                    self.cached_branch = Some(b);
+                    self.cache_populated_at = Some(Instant::now());
+                } else {
+                    log::debug!("Using cached project path and git branch");
+                }
+
+                self.cached_branch.clone().flatten()
             };
 
             self.set_working_activity(&project, &started_at, branch.as_deref())?;


### PR DESCRIPTION
Closes https://linear.app/izyuumi/issue/IZY-7

## Summary

Resolves [izyuumi/ideas#23](https://github.com/izyuumi/ideas/issues/23)

Adds the active git branch name to the Discord Rich Presence state string, giving collaborators meaningful context at a glance.

### What changed

| File | Change |
|------|--------|
| `src/utils/git.rs` | New module: `get_git_branch` + `format_branch_state` utilities |
| `src/utils/osascript.rs` | New `current_project_path()` AppleScript helper |
| `src/utils/mod.rs` | Expose `pub mod git` |
| `src/config.rs` | Add `hide_branch` field + `--hide-branch` / `-b` CLI flag |
| `src/xcode_state.rs` | Resolve branch each poll cycle; pass to `get_project_state` |
| `default.toml` | `hide_branch = false` default |
| `docs/config.md` | Document new option |

### How it works

1. On each update cycle the app calls `current_project_path()` (AppleScript: `path of active workspace document`) to get the workspace file path.
2. That path is passed to `get_git_branch`, which runs `git -C <dir> rev-parse --abbrev-ref HEAD`. Detached-HEAD is silently omitted.
3. The branch name is appended to the state string with a bullet separator, e.g. `in MyApp • feat/export`.
4. Long branch names are truncated at a UTF-8 character boundary with an `…` suffix so the state never exceeds Discord's 128-byte limit.
5. If the project is not inside a git repository the state string is unchanged.

### New config option

```toml
# ~/.config/xcode-discord-rpc/config.toml
hide_branch = true   # default: false
```

Or via CLI flag: `--hide-branch` / `-b`

### Tests

Three unit tests cover `format_branch_state`: short branch (no truncation), exactly-at-limit, and a 200-char branch that must be truncated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Toggle to hide/show the active Git branch in Discord status; new CLI flags for config path, disable-idle, and hide-branch; graceful Ctrl+C shutdown with cleanup.

* **Documentation**
  * Updated docs and help text describing new options, branch behavior, and CLI usage.

* **Tests**
  * Added unit tests for branch formatting and truncation to respect byte limits.

* **Performance**
  * Short-lived caching of project path and branch to reduce lookups.

* **Bug Fixes**
  * Improved AppleScript/path parsing and clearer error messages; transient error classification.

* **Chore**
  * Release bumped, changelog updated, and CI/Homebrew tap reference adjusted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->